### PR TITLE
docs: Add security and migration notes to MCP_TOOL_OBJECT_MIGRATION.md (closes #72)

### DIFF
--- a/docs/Implementation_Docs/MCP_TOOL_OBJECT_MIGRATION.md
+++ b/docs/Implementation_Docs/MCP_TOOL_OBJECT_MIGRATION.md
@@ -58,6 +58,23 @@ This document tracks the migration of all MCP tool definitions in `handle_list_t
 - [x] correlate_threat_indicators
 - [x] get_threat_intelligence_summary
 
+## 🔒 Security Implications
+
+- **Type Safety:** Migrating to `Tool` objects enforces type safety and prevents runtime errors due to unexpected dictionary structures. This reduces the risk of malformed tool definitions being registered or invoked.
+- **Error Handling:** The new implementation ensures that all tools are validated at initialization, and errors are caught early in the server startup process. This prevents exposure of internal errors to clients and improves overall robustness.
+- **Data Exposure:** Only properly defined and validated tools are listed and callable, reducing the risk of accidental exposure of internal or experimental tools.
+- **Protocol Compliance:** Using `Tool` objects ensures strict adherence to the MCP protocol, preventing malformed or malicious tool definitions from affecting the server.
+
+## 🔄 Migration Notes
+
+- **Backward Compatibility:** The migration is fully backward compatible for clients. All existing tool invocations and workflows continue to work, with improved type safety and error handling.
+- **Configuration:** No additional configuration is required. The migration is handled internally in the server code.
+- **Upgrade Steps:**
+  1. Update your MCP server to the latest version with the `Tool` object migration.
+  2. Review and test tool listing and invocation with your existing workflows.
+  3. Monitor for any new errors or issues after deployment.
+- **Deprecations:** No breaking changes or deprecated features are introduced in this release. All previous tool functionality is preserved.
+
 ## Summary
 - All MCP tool definitions have been migrated to use the `Tool` object.
 - The server now lists and registers all tools correctly, and the previous runtime error is resolved.


### PR DESCRIPTION
# Add Security and Migration Notes to MCP Tool Object Migration Doc

This PR addresses [issue #72](https://github.com/datagen24/dsheild-mcp/issues/72) by adding the following sections to `MCP_TOOL_OBJECT_MIGRATION.md`:

- **Security Implications:**
  - Type safety and prevention of malformed tool definitions
  - Early error handling and improved robustness
  - Data exposure minimization and protocol compliance
- **Migration Notes:**
  - Backward compatibility for clients and workflows
  - No additional configuration required
  - Step-by-step upgrade guidance
  - No breaking changes or deprecated features

## Checklist
- [x] Added security implications section
- [x] Added migration notes section
- [x] Verified doc structure and clarity
- [x] References and closes #72

---

Please review and merge. This brings the documentation into compliance with project requirements for security and migration guidance. 