### PR TITLE
docs: Add dependencies section to docs/README.md (closes #73)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,27 @@ docs/
 ├── CAMPAIGN_ANALYSIS_IMPLEMENTATION.md # Campaign analysis implementation guide
 ```
 
+## Dependencies
+
+- **Python Packages:**
+  - `elasticsearch` (for Elasticsearch queries and backend integration)
+  - `structlog` (for structured logging and error reporting)
+  - `aiohttp` (for async HTTP requests)
+  - `pydantic` (for data validation and typing)
+  - `pytest` (for running tests)
+  - `ruff` (for linting and docstring compliance)
+  - `pdoc` (for HTML API documentation generation)
+  - `pydoc-markdown` (for Markdown API documentation generation)
+- **Elasticsearch:**
+  - Requires a running Elasticsearch instance (version 7.x, 8.x, or 9.x; see compatibility notes below)
+- **Testing and Documentation Tools:**
+  - `pytest` for test automation
+  - `ruff` for linting and docstring checks
+  - `pdoc` for HTML API docs
+  - `pydoc-markdown` for Markdown API docs
+
+See `requirements.txt` and `requirements-dev.txt` for full dependency lists and version constraints.
+
 ## 🔗 Related Resources
 
 - **Main Project**: [README.md](../README.md)


### PR DESCRIPTION
# Add Dependencies Section to docs/README.md

This PR addresses [issue #73](https://github.com/datagen24/dsheild-mcp/issues/73) by adding a comprehensive dependencies section to `docs/README.md`:

- **Dependencies:**
  - Lists required Python packages, Elasticsearch, and documentation/testing tools
  - Provides guidance on where to find full dependency lists and version constraints

## Checklist
- [x] Added dependencies section after Documentation Structure
- [x] Verified doc structure and clarity
- [x] References and closes #73

---

Please review and merge. This brings the documentation into compliance with project requirements for dependency tracking and discoverability. 