### PR TITLE
docs: Add dependencies section to OUTPUT_DIRECTORY_CONFIGURATION.md (closes #76)

### DIFF
--- a/docs/OUTPUT_DIRECTORY_CONFIGURATION.md
+++ b/docs/OUTPUT_DIRECTORY_CONFIGURATION.md
@@ -12,6 +12,20 @@ DShield MCP generates various output files including:
 
 All generated files are written to a configurable output directory that is separate from the application installation directory for security and portability.
 
+## Dependencies
+
+- **Python Packages:**
+  - `os`, `pathlib` (standard library, for path handling and directory creation)
+  - `pyyaml` (for YAML configuration parsing)
+  - `structlog` (for logging and error reporting)
+- **Operating System:**
+  - Compatible with Unix/Linux/macOS and Windows
+  - Requires permission to create and write to the configured output directory
+- **Testing:**
+  - `pytest` for test automation
+
+See `requirements.txt` and `requirements-dev.txt` for full dependency lists and version constraints.
+
 ## Default Behavior
 
 By default, all output files are written to:


### PR DESCRIPTION
# Add Dependencies Section to OUTPUT_DIRECTORY_CONFIGURATION.md

This PR addresses [issue #76](https://github.com/datagen24/dsheild-mcp/issues/76) by adding a comprehensive dependencies section to `OUTPUT_DIRECTORY_CONFIGURATION.md`:

- **Dependencies:**
  - Lists required Python packages, OS features, and testing tools
  - Provides guidance on where to find full dependency lists and version constraints

## Checklist
- [x] Added dependencies section after Overview
- [x] Verified doc structure and clarity
- [x] References and closes #76

---

Please review and merge. This brings the documentation into compliance with project requirements for dependency tracking and discoverability. 