### PR TITLE
Fix MCP namespace mismatch causing 'Tool not found' errors

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -93,7 +93,7 @@ class DShieldMCPServer:
         Sets up the server instance, initializes client references,
         loads user configuration, and registers available MCP tools.
         """
-        self.server = Server("dshield-elastic-mcp")
+        self.server = Server("dshield-mcp")
         self.elastic_client = None
         self.dshield_client = None
         self.data_processor = None


### PR DESCRIPTION
## Fix MCP namespace mismatch causing 'Tool not found' errors

Closes #111

### Problem
The MCP server was experiencing namespace mismatch issues that prevented clients from accessing tools:

- **Error 1**: `Tool 'dshield-mcp:query_dshield_events' not found.`
- **Error 2**: `Tool 'query_dshield_events' not found.`

### Root Cause
The MCP server was running with namespace `dshield-elastic-mcp` but the client configuration expected `dshield-mcp`. This namespace mismatch caused all tool access to fail at the protocol level, even though the server's internal tool registration was working correctly.

### Solution
Updated the server namespace in `mcp_server.py` from:
```python
self.server = Server("dshield-elastic-mcp")
```
to:
```python
self.server = Server("dshield-mcp")
```

### Impact
- ✅ Fixes the "Tool not found" errors
- ✅ Restores access to all MCP tools including `query_dshield_events`
- ✅ Aligns server namespace with MCP Inspector configuration
- ✅ No changes needed to tool implementation or configuration

### Testing
- Verified that the server starts correctly with the new namespace
- Confirmed that `query_dshield_events` tool is properly registered and accessible
- All internal health checks and feature availability checks continue to pass

### Files Changed
- `mcp_server.py` - Updated server namespace from `dshield-elastic-mcp` to `dshield-mcp`

### Notes
This was a pure namespace configuration issue - no functional changes to the MCP server's capabilities or tool implementations were required.
